### PR TITLE
fix(library): correct macOS library scanning (case sensitivity, AppleDouble, NFC)

### DIFF
--- a/main.js
+++ b/main.js
@@ -320,6 +320,11 @@ server.post("/list", (req, res) => {
 
       const respData = [];
       for (const file of files) {
+        // macOS writes AppleDouble sidecars ("._Song.mp3") onto exFAT/FAT/SMB
+        // volumes. They carry a real media extension, so without this they get
+        // indexed as playable zero-byte songs and persisted into songdb.json
+        // inside the library -- which then travels back to Windows on the drive.
+        if (file.startsWith("._")) continue;
         const filePath = path.join(dir, file);
         try {
           const fileStats = await fs.promises.stat(filePath);

--- a/src/pkgs/services/FsSvc.js
+++ b/src/pkgs/services/FsSvc.js
@@ -351,9 +351,23 @@ const pkg = {
         return false;
       }
 
-      const cacheKey = `encore-songlist:${libraryPath}`;
-      const signatureKey = `encore-signature:${libraryPath}`;
-      const newSongsKey = `encore-newsongs:${libraryPath}`;
+      // Bumped when the scanner's matching rules change in a way that
+      // invalidates previously cached lists (v2: case-insensitive sibling
+      // matching, AppleDouble filtering, NFC normalization).
+      const cacheKey = `encore-songlist:v2:${libraryPath}`;
+      const signatureKey = `encore-signature:v2:${libraryPath}`;
+      const newSongsKey = `encore-newsongs:v2:${libraryPath}`;
+
+      // macOS readdir returns NFD; Windows/Linux return NFC. songdb.json lives
+      // inside the library and travels with the drive, so every string that
+      // gets compared or used as a key is normalized to NFC first. Raw readdir
+      // names are still used for actual I/O -- APFS/HFS+/exFAT accept either.
+      const nfc = (s) => (typeof s === "string" ? s.normalize("NFC") : s);
+
+      // macOS writes AppleDouble sidecars ("._Song.mp3") onto exFAT/FAT/SMB
+      // volumes. They carry a real media extension and would otherwise be
+      // indexed as playable zero-byte songs.
+      const isAppleDouble = (name) => name.startsWith("._");
 
       const audioExtensions = new Set(["wav", "mp3", "m4a", "ogg"]);
       const videoExtensions = new Set(["mp4", "mkv", "webm", "avi"]);
@@ -369,12 +383,13 @@ const pkg = {
 
       const currentSignature = [...files]
         .filter((f) => {
-          const name = f.name.toLowerCase();
+          if (isAppleDouble(f.name)) return false;
+          const name = nfc(f.name).toLowerCase();
           if (name === "songdb.json" || name === "manifest.json") return false;
           return validExts.has(name.split(".").pop());
         })
         .sort((a, b) => a.name.localeCompare(b.name))
-        .map((f) => `${f.name}:${f.modified}`)
+        .map((f) => `${nfc(f.name)}:${f.modified}`)
         .join("|");
 
       const cachedSignature = await localforage.getItem(signatureKey);
@@ -392,9 +407,11 @@ const pkg = {
       }
 
       const toRelative = (p) =>
-        p && (p.includes("/") || p.includes("\\"))
-          ? p.replace(/\\/g, "/").split("/").pop()
-          : p;
+        nfc(
+          p && (p.includes("/") || p.includes("\\"))
+            ? p.replace(/\\/g, "/").split("/").pop()
+            : p,
+        );
       const toAbsolute = (p) => (p ? `${libraryPath}${p}` : null);
 
       // water up 💧💧💧
@@ -491,15 +508,21 @@ const pkg = {
         }
       }
 
-      const allFilenames = new Set(files.map((f) => f.name));
-
-      const processableFiles = files.filter(
-        (file) =>
-          file.type === "file" &&
-          (audioExtensions.has(file.name.split(".").pop().toLowerCase()) ||
-            file.name.endsWith(".mid") ||
-            file.name.endsWith(".kar")),
+      // Case- and normalization-insensitive index of what's on disk. Commercial
+      // CDG libraries are typically all-uppercase ("SONG.MP3" + "SONG.CDG"),
+      // and an exact-case Set lookup silently fails to pair them. Maps the
+      // folded name back to the real on-disk name, which is what I/O needs.
+      const byLower = new Map(
+        files.map((f) => [nfc(f.name).toLowerCase(), f.name]),
       );
+      const findSibling = (name) =>
+        byLower.get(nfc(name).toLowerCase()) || null;
+
+      const processableFiles = files.filter((file) => {
+        if (file.type !== "file" || isAppleDouble(file.name)) return false;
+        const ext = nfc(file.name).split(".").pop().toLowerCase();
+        return audioExtensions.has(ext) || ext === "mid" || ext === "kar";
+      });
 
       processableFiles.sort((a, b) => a.name.localeCompare(b.name));
 
@@ -537,28 +560,24 @@ const pkg = {
 
             let videoName = null;
             for (const videoExt of videoExtensions) {
-              const potentialVideoName = `${basename}.${videoExt}`;
-              if (allFilenames.has(potentialVideoName)) {
-                videoName = potentialVideoName;
-                break;
-              }
+              videoName = findSibling(`${basename}.${videoExt}`);
+              if (videoName) break;
             }
 
             let chorusName = null;
             for (const audioExt of audioExtensions) {
-              const potentialChorusName = `${basename}.chorus.${audioExt}`;
-              if (allFilenames.has(potentialChorusName)) {
-                chorusName = potentialChorusName;
-                break;
-              }
+              chorusName = findSibling(`${basename}.chorus.${audioExt}`);
+              if (chorusName) break;
             }
 
             let songData = null;
             let artist = "Unknown Artist";
             let title = basename.replace(/\[.*?\]/g, "").trim();
 
-            const hasLrc = allFilenames.has(`${basename}.lrc`);
-            const hasCdg = allFilenames.has(`${basename}.cdg`);
+            const lrcName = findSibling(`${basename}.lrc`);
+            const cdgName = findSibling(`${basename}.cdg`);
+            const hasLrc = Boolean(lrcName);
+            const hasCdg = Boolean(cdgName);
 
             if (audioExtensions.has(extension) && (hasLrc || hasCdg)) {
               if (state.buildAbortController?.signal.aborted) {
@@ -566,8 +585,8 @@ const pkg = {
               }
               songData = {
                 type: isMultiplexed ? "multiplexed" : hasCdg ? "cdg" : "audio",
-                lrcPath: hasLrc ? `${basename}.lrc` : null,
-                cdgPath: hasCdg ? `${basename}.cdg` : null,
+                lrcPath: lrcName,
+                cdgPath: cdgName,
               };
               try {
                 const urlObj = await NetworkingUtility.getFileLink(fullPath);


### PR DESCRIPTION
Fixes three defects that make a real karaoke library scan incorrectly on macOS. Split out of the macOS work in #43 because these are plain bug fixes and don't depend on any of the packaging decisions there.

## The bugs

**Uppercase libraries scan wrong.** `audioExtensions` (`FsSvc.js:358`) doesn't contain `"mid"`, so `SONG.MID` fails the lowercased set check and falls through to `file.name.endsWith(".mid")`, which is case-sensitive, and is dropped entirely. Separately, sibling lookups used an exact-case `Set`, so `SONG.MP3` + `SONG.CDG` searched for `SONG.cdg`, missed, and the song silently lost its graphics. Commercial CDG libraries are overwhelmingly uppercase.

**AppleDouble files become phantom songs.** macOS writes `._Song.mp3` sidecars onto exFAT/FAT/SMB volumes. They carry a real media extension, so `/list` (`main.js:317`) indexed them as playable zero-byte songs — and they were persisted into `songdb.json` inside the library folder, so they travel back to Windows on the same drive. (`.DS_Store` was already excluded by the extension check; this is specifically AppleDouble.)

**NFC/NFD.** macOS `readdir` returns NFD while Windows/Linux return NFC. Since `songdb.json` lives inside the library and travels with the drive, a Windows-authored cache opened on a Mac mismatches on any accented or Japanese title — and one such filename invalidates the entire cached signature.

## Reproduction

Against a fixture of 4 real songs (`SONG ONE.MP3` + `SONG ONE.CDG`, `song two.mp3` + `song two.cdg`, `SONG THREE.MID`, `song four.mid`, plus the `._` sidecars macOS creates):

| | before | after |
|---|---|---|
| entries shown | 5 | 4 |
| AppleDouble phantoms | 2 | 0 |
| `SONG ONE` paired with its `.CDG` | no | yes |
| `SONG THREE.MID` present | no | yes |

## Approach

Sibling matching now goes through a case- and normalization-folded index that returns the **real on-disk name**, so `cdgPath` gets `SONG ONE.CDG` rather than a reconstructed `SONG ONE.cdg` — matching case-insensitively and then handing a wrong-case path to I/O would just move the failure. Raw `readdir` names are still used for actual I/O, since APFS/HFS+/exFAT accept either normalization form.

Cache keys are bumped to `v2` so lists built under the old rules are discarded rather than silently retained.

`allFilenames` is removed because every lookup now routes through the new index; leaving it would be a trap for whoever adds the next sibling type.

## Risk

Behaviour on an all-lowercase library on Windows is unchanged — the folded index returns the same names the exact-case `Set` did. The one visible change for existing users is a one-time library rebuild from the cache-key bump.
