### PR TITLE
build: pin engines to node >=22 <26 (Node 26 makes packaging silently produce nothing)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.10.0",
   "description": "Turn your PC into a karaoke machine, complete with scoring and recording features. For karaoke fans, by karaoke fans. Runs offline.",
   "main": "dist/main.js",
+  "engines": {
+    "node": ">=22 <26"
+  },
   "scripts": {
     "build": "node build.js",
     "build:dev": "node build.js --dev",


### PR DESCRIPTION
## The problem

On Node 26, `npm run package` and `npm run make` print the normal progress tree, end at "Finalizing package", **exit 0, and create no `out/` directory at all.** No error, no warning, no partial artifact — the build reports success having produced nothing.

This is not macOS-specific. It breaks Windows and Linux packaging identically.

## Cause

`@electron/packager` unpacks the cached Electron zip with `extract-zip@2.0.1` → `yauzl@2.10.0`. Under Node 26 that extraction writes **exactly one entry** and then its promise never settles. Node sees an empty event loop and exits cleanly, so Forge reports success.

Reproduced outside Forge entirely, straight against the cached zip:

```js
import extract from "extract-zip";
await extract(CACHED_ELECTRON_ZIP, { dir: OUT });
```

- **Node 26.5.0** — `OUT` contains only `LICENSES.chromium.html`, and Node prints `Warning: Detected unsettled top-level await`
- **Node 22.14.0** — `EXTRACT OK in 1626 ms`, `OUT` contains `Electron.app`, `LICENSE`, `version`

That warning is the tell: the process ran out of work with a promise still pending, which is what a dropped stream callback looks like.

## Why this is worth pinning rather than documenting

The failure is invisible and misattributing. Because it *succeeds emptily* rather than failing, every instinct points at whatever you last changed in `forge.config.js`. The diagnostic that actually settles it is to stash your changes and package the untouched tree — if the baseline also produces no `out/`, it's the toolchain.

There's a second trap layered on top: `npx electron-forge package | tail` reports `tail`'s exit code, not Forge's, so `$?` looks clean even if Forge did fail.

## Notes

`engines` is advisory unless `engine-strict=true` is set in `.npmrc`, so it's worth pinning the runtime explicitly in CI too (`actions/setup-node` with `node-version: 22`). I've left `.npmrc` alone since making engines strict repo-wide is a bigger call than this fix.

This is orthogonal to `target: "node24"` in `build.js` — that's esbuild's output syntax level, not the runtime doing the packaging.

Upper bound is `<26` rather than a specific patch because the fix has to come from `extract-zip`/`yauzl` upstream; it can be relaxed once a packager release ships a working extraction path.

Found while working on macOS support (#43), but filed separately since it affects every platform.
